### PR TITLE
Support laravel 7 and 8 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "minimum-stability": "dev",
     "prefer-stable":true,
     "require": {
-        "graham-campbell/security": "^6.1"
+        "graham-campbell/security": "^9.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4@dev",
+        "phpunit/phpunit": "^8.4@dev",
         "mockery/mockery": "^1.0@dev",
-        "orchestra/testbench": "^3.8@dev",
-        "orchestra/database": "^3.8@dev",
-        "illuminate/support": "^5.8@dev",
+        "orchestra/testbench": "^5.0@dev",
+        "orchestra/database": "^5.0@dev|^6.0@dev",
+        "illuminate/support": "^7.0@dev || ^8.0@dev",
         "fzaninotto/faker": "^1.9@dev"
     },
     "autoload": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,9 +17,9 @@ class TestCase extends BaseTestCase
     ];
 
     protected $cleanData = [
-        'username' => '<a xss=removed>test xss</a>',
+        'username' => '<a >test xss</a>',
         'deep-array' => [
-            'username' => '<a xss=removed>test xss</a>',
+            'username' => '<a >test xss</a>',
         ],
     ];
 


### PR DESCRIPTION
-> Updated graham-campbell/security to 9.0, as well as some other development packages eg orchestra/testbench, orchestra/database, illuminate/support and phpunit/phpunit": "^7.4@dev,

-> Fixed failing tests, in previous version of graham-campbell/security

```
$this->assertSame('<span xss=removed>X</span>', Facade::clean('<span/onmouseover=confirm(1)>X</span>'));
```
in latest version of graham/campbell/security
```
$this->assertSame('<span/>X</span>', Facade::clean('<span/onmouseover=confirm(1)>X</span>'));
```

notice that the `xss=removed` added to previous version as been removed in version 9.0