### PR TITLE
fix: restore graham-campbell/security parity (BC follow-up for #7)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,99 @@
+# Upgrade guide
+
+## From v4 to v5
+
+### Backend swap
+
+The package no longer depends on `graham-campbell/security` / `graham-campbell/security-core`. The XSS sanitizer is now `voku/anti-xss` directly. Same underlying engine — graham-campbell was already a thin wrapper around voku — but the public surface that came with the wrapper is gone.
+
+### Drop-in for `app('security')` — no change required
+
+`app('security')` still resolves to a `Security` instance with a `clean()` method that behaves identically to `GrahamCampbell\SecurityCore\Security::clean()`:
+
+- `xss_clean()` then C0 control-character strip (raw + URL-encoded), preserving TAB / LF / CR
+- if the strip mutated the value, re-run `xss_clean()` (defends against payloads hidden behind invisible chars)
+
+If you only ever call `app('security')->clean(...)`, **no code changes are needed**.
+
+### Drop-in for type-hints — swap the `use` statement
+
+If you were type-hinting `\GrahamCampbell\SecurityCore\Security` (constructor injection, controller method parameter, factory pattern, etc.), update your imports:
+
+```diff
+- use GrahamCampbell\SecurityCore\Security;
++ use Alkhwlani\XssMiddleware\Security;
+```
+
+The class shape, constructor, and `clean()` semantics match the original.
+
+### Subclasses overriding `transform()`
+
+If you subclass `XSSFilterMiddleware` and override `transform()`, `$this->security` is still a `Security` instance with a `clean()` method — same as v4. `$this->security->clean($value)` continues to work.
+
+### Facade users — install graham-campbell/security separately
+
+This package no longer ships the `GrahamCampbell\Security\Facades\Security` facade.
+
+If your code uses that facade (e.g. `Security::clean(...)` via `use GrahamCampbell\Security\Facades\Security;`):
+
+**On Laravel 10 / 11** — install `graham-campbell/security` directly to keep the facade:
+
+```bash
+composer require graham-campbell/security:^11.0
+```
+
+The facade keeps working. graham-campbell's service provider re-binds `'security'` after ours, so `Security::clean(...)` via the facade resolves through their wrapper. The middleware itself is unaffected — it resolves `Alkhwlani\XssMiddleware\Security` via its FQCN, not via the `'security'` alias.
+
+**On Laravel 12 / 13** — `graham-campbell/security` does not support these versions. Migrate the facade calls to either:
+
+```php
+// option A — type-hint our Security class
+use Alkhwlani\XssMiddleware\Security;
+
+class Foo {
+    public function __construct(private Security $security) {}
+    public function bar() { $this->security->clean($input); }
+}
+
+// option B — resolve from the container
+app('security')->clean($input);
+```
+
+### `Security::create($evil, $replacement)` static factory
+
+The static factory is not provided by this package. The same configuration is now done declaratively via `config/xss-middleware.php`:
+
+```php
+'evil' => [
+    'attributes'         => [...],   // addEvilAttributes
+    'tags'               => [...],   // addEvilHtmlTags
+    'regex'              => [...],   // addNeverAllowedRegex
+    'events'             => [...],   // addNeverAllowedOnEventsAfterwards
+    'strAfterwards'      => [...],   // addNeverAllowedStrAfterwards
+    'doNotCloseHtmlTags' => [...],   // addDoNotCloseHtmlTags
+],
+'replacement' => '...',
+```
+
+The values are applied to the `voku\helper\AntiXSS` singleton on first resolve.
+
+### Config publishing
+
+Re-publish the config to pick up the new `evil` / `replacement` keys:
+
+```bash
+php artisan vendor:publish --provider="Alkhwlani\\XssMiddleware\\ServiceProvider" --tag=config --force
+```
+
+### `evil` config shape
+
+The `evil` key now expects an associative array:
+
+```php
+'evil' => [
+    'attributes' => ['style'],
+    'tags'       => ['svg'],
+],
+```
+
+A flat list of attribute names (the old graham-campbell single-arg shape) is still accepted, but emits an `E_USER_DEPRECATED` notice and will be removed in a future major. Update your published config to the associative shape.

--- a/config/xss-middleware.php
+++ b/config/xss-middleware.php
@@ -28,16 +28,19 @@ return [
 
     /*
      |--------------------------------------------------------------------------
-     | Evil attributes / tags
+     | Evil options
      |--------------------------------------------------------------------------
      |
-     | Additional HTML attributes and tags that should always be stripped from
-     | the input, on top of voku/anti-xss's built-in evil list. Set to null to
-     | use only the defaults.
+     | Custom evil patterns to strip on top of voku/anti-xss's built-in list.
+     | All sub-keys are optional; set to null or omit to skip.
      |
      |     'evil' => [
-     |         'attributes' => ['style', 'srcdoc'],
-     |         'tags'       => ['svg', 'math'],
+     |         'attributes'         => ['style', 'srcdoc'],   // addEvilAttributes
+     |         'tags'               => ['svg', 'math'],        // addEvilHtmlTags
+     |         'regex'              => ['/foo[0-9]+/'],        // addNeverAllowedRegex
+     |         'events'             => ['onmycustom'],         // addNeverAllowedOnEventsAfterwards
+     |         'strAfterwards'      => ['SECRET'],             // addNeverAllowedStrAfterwards
+     |         'doNotCloseHtmlTags' => ['br', 'hr'],           // addDoNotCloseHtmlTags
      |     ],
      */
     'evil' => [

--- a/src/Security.php
+++ b/src/Security.php
@@ -13,7 +13,9 @@ use voku\helper\UTF8;
  */
 class Security
 {
-    public function __construct(private readonly AntiXSS $antiXss) {}
+    public function __construct(private readonly AntiXSS $antiXss)
+    {
+    }
 
     /**
      * Sanitize the given value.

--- a/src/Security.php
+++ b/src/Security.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Alkhwlani\XssMiddleware;
+
+use voku\helper\AntiXSS;
+use voku\helper\UTF8;
+
+/**
+ * Drop-in replacement for the previous graham-campbell/security-core
+ * `Security` class. Resolved via the `app('security')` binding; consumers
+ * upgrading from v4 only need to swap their `use` statement to this
+ * class (or use `app('security')` and avoid the type-hint entirely).
+ */
+class Security
+{
+    public function __construct(private readonly AntiXSS $antiXss) {}
+
+    /**
+     * Sanitize the given value.
+     *
+     * Runs the value through voku/anti-xss, strips C0 control characters,
+     * and — if stripping changed the string — re-runs voku to defend
+     * against payloads that were hiding behind invisible characters.
+     *
+     * @param  string|array<int|string, mixed>  $input
+     * @return string|array<int|string, mixed>
+     */
+    public function clean(mixed $input): mixed
+    {
+        $output = $this->antiXss->xss_clean($input);
+
+        if ($this->antiXss->isXssFound() === true) {
+            return $output;
+        }
+
+        $stripped = self::cleanInvisibleCharacters($output);
+
+        // Re-clean only if invisible-character stripping mutated the value
+        // — a payload may have been concealed behind C0 control bytes.
+        return $stripped == $output ? $output : $this->antiXss->xss_clean($stripped);
+    }
+
+    /**
+     * @param  string|array<int|string, mixed>  $input
+     * @return string|array<int|string, mixed>
+     */
+    private static function cleanInvisibleCharacters(mixed $input): mixed
+    {
+        if (is_array($input)) {
+            foreach ($input as $key => &$value) {
+                $value = self::cleanInvisibleCharacters($value);
+            }
+
+            return $input;
+        }
+
+        if (! is_string($input)) {
+            return $input;
+        }
+
+        return UTF8::remove_invisible_characters($input, true);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,18 +27,17 @@ class ServiceProvider extends ServiceProviderAlias
                 $antiXss->setReplacement($replacement);
             }
 
-            $evil = $config['evil'] ?? null;
-            if (is_array($evil)) {
-                if (! empty($evil['attributes'])) {
-                    $antiXss->addEvilAttributes($evil['attributes']);
-                }
-                if (! empty($evil['tags'])) {
-                    $antiXss->addEvilHtmlTags($evil['tags']);
-                }
-            }
+            self::applyEvilOptions($antiXss, $config['evil'] ?? null);
 
             return $antiXss;
         });
+
+        $this->app->singleton(Security::class, fn (Container $app) => new Security($app->make(AntiXSS::class)));
+
+        // BC: graham-campbell/security used to bind `app('security')` transitively.
+        // Keep the binding so existing consumers continue to resolve a Security
+        // instance with the same `clean()` API.
+        $this->app->alias(Security::class, 'security');
     }
 
     /**
@@ -88,5 +87,54 @@ class ServiceProvider extends ServiceProviderAlias
         }
 
         $this->mergeConfigFrom(__DIR__.'/../config/xss-middleware.php', 'xss-middleware');
+    }
+
+    /**
+     * Wire the configured `evil` options onto the AntiXSS instance.
+     *
+     * Accepts the new associative shape (`['attributes' => [...], 'tags' => [...]]`)
+     * and four additional keys mirrored from graham-campbell/security-core:
+     * `regex`, `events`, `strAfterwards`, `doNotCloseHtmlTags`.
+     *
+     * For backward compatibility, a flat list of attribute names is also
+     * accepted (graham-campbell shape) and routed to `addEvilAttributes()`,
+     * with an `E_USER_DEPRECATED` notice.
+     */
+    private static function applyEvilOptions(AntiXSS $antiXss, mixed $evil): void
+    {
+        if (! is_array($evil) || $evil === []) {
+            return;
+        }
+
+        if (array_is_list($evil)) {
+            @trigger_error(
+                'xss-middleware: the flat-array shape for the "evil" config key is deprecated. '
+                .'Use ["attributes" => [...], "tags" => [...]] instead. The flat shape will be '
+                .'removed in v6.',
+                E_USER_DEPRECATED
+            );
+            $antiXss->addEvilAttributes($evil);
+
+            return;
+        }
+
+        if (! empty($evil['attributes'])) {
+            $antiXss->addEvilAttributes($evil['attributes']);
+        }
+        if (! empty($evil['tags'])) {
+            $antiXss->addEvilHtmlTags($evil['tags']);
+        }
+        if (! empty($evil['regex'])) {
+            $antiXss->addNeverAllowedRegex($evil['regex']);
+        }
+        if (! empty($evil['events'])) {
+            $antiXss->addNeverAllowedOnEventsAfterwards($evil['events']);
+        }
+        if (! empty($evil['strAfterwards'])) {
+            $antiXss->addNeverAllowedStrAfterwards($evil['strAfterwards']);
+        }
+        if (! empty($evil['doNotCloseHtmlTags'])) {
+            $antiXss->addDoNotCloseHtmlTags($evil['doNotCloseHtmlTags']);
+        }
     }
 }

--- a/src/XSSFilterMiddleware.php
+++ b/src/XSSFilterMiddleware.php
@@ -4,8 +4,6 @@ namespace Alkhwlani\XssMiddleware;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Http\Middleware\TransformsRequest;
-use voku\helper\AntiXSS;
-use voku\helper\UTF8;
 
 class XSSFilterMiddleware extends TransformsRequest
 {
@@ -15,13 +13,13 @@ class XSSFilterMiddleware extends TransformsRequest
     protected $config;
 
     /**
-     * @var AntiXSS
+     * @var Security
      */
     protected $security;
 
     public function __construct(Repository $config)
     {
-        $this->security = app(AntiXSS::class);
+        $this->security = app(Security::class);
         $this->config = $config->get('xss-middleware');
     }
 
@@ -38,17 +36,7 @@ class XSSFilterMiddleware extends TransformsRequest
             return $value;
         }
 
-        $cleaned = $this->security->xss_clean($value);
-
-        // When the value did not contain XSS, voku leaves C0 control characters
-        // (NUL, BEL, ESC, …) and DEL intact. Strip them anyway — they are
-        // common vectors for null-byte injection, log-poisoning, and terminal
-        // escape attacks, and have no place in user input.
-        if (is_string($cleaned) && $this->security->isXssFound() === false) {
-            $cleaned = UTF8::remove_invisible_characters($cleaned, true);
-        }
-
-        return $cleaned;
+        return $this->security->clean($value);
     }
 
     /**

--- a/tests/EvilOptionsTest.php
+++ b/tests/EvilOptionsTest.php
@@ -32,12 +32,50 @@ class EvilOptionsTest extends TestCase
         $this->assertStringContainsString('safe', $response);
     }
 
+    #[Test]
+    public function it_strips_str_afterwards_substrings_when_configured()
+    {
+        $payload = ['snippet' => 'hello SECRET_TOKEN world'];
+
+        $response = $this->post('add-middleware-auto', $payload)->json('snippet');
+
+        $this->assertStringNotContainsString('SECRET_TOKEN', $response);
+        $this->assertStringContainsString('world', $response);
+    }
+
+    #[Test]
+    public function it_strips_custom_event_handlers_when_configured()
+    {
+        $payload = ['snippet' => '<a onmycustom="alert(1)">x</a>'];
+
+        $response = $this->post('add-middleware-auto', $payload)->json('snippet');
+
+        $this->assertStringNotContainsString('onmycustom', $response);
+    }
+
+    #[Test]
+    public function flat_evil_array_still_works_for_old_published_configs()
+    {
+        // Old graham-campbell shape: bare list of attribute names. Routed onto
+        // addEvilAttributes() with a deprecation notice.
+        $this->app['config']->set('xss-middleware.evil', ['data-evil']);
+
+        $payload = ['snippet' => '<p data-evil="x">hi</p>'];
+
+        $response = @$this->post('add-middleware-auto', $payload)->json('snippet');
+
+        $this->assertStringNotContainsString('data-evil=', $response);
+        $this->assertStringContainsString('hi', $response);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
         $app['config']->set('xss-middleware.evil', [
             'attributes' => ['style'],
             'tags' => ['svg'],
+            'events' => ['onmycustom'],
+            'strAfterwards' => ['SECRET_TOKEN'],
         ]);
     }
 }

--- a/tests/InvisibleCharactersTest.php
+++ b/tests/InvisibleCharactersTest.php
@@ -38,4 +38,18 @@ class InvisibleCharactersTest extends TestCase
         $this->post('add-middleware-auto', $payload)
             ->assertJson(['snippet' => "line1\nline2\tindented\r\nline3"]);
     }
+
+    #[Test]
+    public function it_re_runs_xss_clean_when_invisible_strip_changes_the_string()
+    {
+        // Hide an event handler behind a C0 byte. Plain xss_clean wouldn't
+        // detect it because the bytes break the attribute parser, but after
+        // stripping invisibles a second xss_clean pass catches it.
+        $payload = ['snippet' => '<a on'."\x01".'click="alert(1)">x</a>'];
+
+        $response = $this->post('add-middleware-auto', $payload)->json('snippet');
+
+        $this->assertStringNotContainsString('alert', $response);
+        $this->assertStringNotContainsString("\x01", $response);
+    }
 }


### PR DESCRIPTION
## Summary

Backward-compatibility follow-up for #7 (which is correct in approach, but is a breaking change tagged as `4.1.0`).

PR #7 silently broke three things for v4 consumers:

1. **`app('security')->clean(...)`** outside the middleware throws `BindingResolutionException` — `graham-campbell/security`'s service provider used to register that binding transitively.
2. **Subclasses overriding `transform()`** that call `\$this->security->clean(\$value)` hit `BadMethodCallException`, because `\$this->security` was retyped to `voku\helper\AntiXSS` (which only has `xss_clean()`).
3. **The `evil` config key** changed shape from a flat list (graham-campbell) to `['attributes' => [...], 'tags' => [...]]` (new). Apps that published the old vendor config and customized `evil` got no error and no effect — a security regression masquerading as a working upgrade.

This PR restores parity for all three.

## What changed

### New: `Alkhwlani\XssMiddleware\Security`
Drop-in replacement for `GrahamCampbell\SecurityCore\Security`. Same `clean()` pipeline:
- `xss_clean` → C0 control-character strip (raw + URL-encoded, preserving TAB/LF/CR) → re-`xss_clean` if the strip mutated the string
- Same loose-equality compare, same recursive array handling, same `UTF8::remove_invisible_characters(\$x, true)` call

### `ServiceProvider`
- Binds `Security::class` as a singleton and aliases it to `'security'` — `app('security')->clean(...)` keeps working.
- Wires the four extra evil sub-keys that graham-campbell exposed (`regex`, `events`, `strAfterwards`, `doNotCloseHtmlTags`).
- Detects the old flat-list `evil` shape, emits an `E_USER_DEPRECATED` notice, and routes it onto `addEvilAttributes()` so apps with old published configs don't silently lose their custom evil list.

### `XSSFilterMiddleware`
- `\$this->security` is once again the `Security` wrapper type (matches the v4 protected-property type contract).
- `transform()` reduces to a one-liner that delegates to `Security::clean()`. Subclasses that override `transform()` and call `\$this->security->clean(\$value)` keep working.

### `UPGRADE.md`
New file. Covers:
- `app('security')->clean(...)` consumers — no change needed.
- `\GrahamCampbell\SecurityCore\Security` type-hint consumers — swap the `use` to `Alkhwlani\XssMiddleware\Security`.
- `XSSFilterMiddleware` subclasses — no change needed.
- Facade users on **L10/L11** — `composer require graham-campbell/security:^11.0` directly. The facade keeps working; their service provider re-binds `'security'` after ours, so `Security::clean(...)` via the facade resolves through their wrapper. The middleware itself is unaffected (it resolves `Security::class` via FQCN, not the `'security'` alias).
- Facade users on **L12/L13** — `graham-campbell/security` has no L12+ release; migrate to type-hinting `Alkhwlani\XssMiddleware\Security` or call `app('security')->clean(...)` directly.
- `Security::create()` static factory replaced by declarative `config/xss-middleware.php`.

## Tests

12 tests, 17 assertions, all green (PHP 8.3 + Laravel 12 testbench locally):
- `EvilOptionsTest` gained four cases — extra sub-keys (`strAfterwards`, custom event names) + flat-array BC with deprecation notice.
- `InvisibleCharactersTest` gained the re-clean-when-strip-mutates case (payload hidden behind a C0 byte).

## Versioning note (for the maintainer)

The merge of #7 was tagged as **`4.1.0`** — but consumers of `^4.0` who rebuild their lockfile will pull a release that has the three BC breaks listed above. Suggest yanking `4.1.0` on Packagist after this PR merges and cutting **`5.0.0`** instead. The README version table can then list `5.X` for L10–L13.

## Out of scope

- Class-aliasing `\GrahamCampbell\SecurityCore\Security` to `\Alkhwlani\XssMiddleware\Security` to satisfy old type-hints. Risky — would collide if any other dep still pulls in `graham-campbell/security-core`. Documented as a manual `use`-statement swap in `UPGRADE.md`.
- Reading `config('security.evil')` as a fallback for apps that customized graham-campbell's separately-publishable config. Niche; `UPGRADE.md` tells those apps to re-publish under the new name.